### PR TITLE
Removed print statement in from_yaml in GPSTime

### DIFF
--- a/gps_time/core.py
+++ b/gps_time/core.py
@@ -237,7 +237,6 @@ class GPSTime:
         time_of_week = None
         for i in range(0, len(nodes)):
             node_name = nodes[i][0].value
-            print(node_name)
             if node_name == "week_number":
                 week_number = constructor.construct_scalar(nodes[i][1])
             elif node_name == "seconds":

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -344,7 +344,6 @@
     "        time_of_week = None\n",
     "        for i in range(0, len(nodes)):\n",
     "            node_name = nodes[i][0].value\n",
-    "            print(node_name)\n",
     "            if node_name == \"week_number\":\n",
     "                week_number = constructor.construct_scalar(nodes[i][1])\n",
     "            elif node_name == \"seconds\":\n",


### PR DESCRIPTION
"time_of_week" and "week_number" was printed whenever GPSTime was parsed from a yaml file. To fix this, I removed the print statement. 